### PR TITLE
Tcoffee alncompare

### DIFF
--- a/modules/nf-core/tcoffee/alncompare/main.nf
+++ b/modules/nf-core/tcoffee/alncompare/main.nf
@@ -21,7 +21,9 @@ process TCOFFEE_ALNCOMPARE {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: '-compare_mode tc'
+    // First check if the flag is given at all and if not put the argument needed, then if given and contains the argument leave it as it is
+    // otherwise add at the beginning the necessary flag to the given arg by the user
+    def args = task.ext.args ? ( task.ext.args.contains('-compare_mode tc') ? task.ext.args  : ('-compare_mode tc ' + task.ext.args)) : '-compare_mode tc'
     def header = meta.keySet().join(",")
     def values = meta.values().join(",")
 

--- a/modules/nf-core/tcoffee/alncompare/main.nf
+++ b/modules/nf-core/tcoffee/alncompare/main.nf
@@ -47,7 +47,7 @@ process TCOFFEE_ALNCOMPARE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        t_coffee: \$( t_coffee -version | sed 's/.*(Version_\\(.*\\)).*/\\1/' )
+        t_coffee: \$( t_coffee -version | awk -F'ersion_' '{print \$2}' | cut -d ' ' -f 1 )
     END_VERSIONS
     """
 }

--- a/tests/modules/nf-core/tcoffee/alncompare/main.nf
+++ b/tests/modules/nf-core/tcoffee/alncompare/main.nf
@@ -17,8 +17,9 @@ workflow test_tcoffee_alncompare {
     ]
 
     ch_aln=FAMSA_ALIGN ( input , [[:],[]] ).alignment
-    ch_to_eval=ch_aln.combine(input2, by:0)
-
+    ch_ref=Channel.of(input2)
+    ch_to_eval=ch_aln.combine(ch_ref, by:0)
+    TCOFFEE_ALNCOMPARE( ch_to_eval )
 
 }
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`

The code now has a better handling of the args flag in regard of the presence of the mandatory flag for t_coffee `-compare_mode tc` .  The pytest now does not fail for Docker, there was a missing cal of the actual process it was suppose to test and a wrong combine call.